### PR TITLE
feat(azure): Implement Azure Account Management API

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/AzureConfigurationProperties.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/AzureConfigurationProperties.groovy
@@ -18,15 +18,20 @@ package com.netflix.spinnaker.clouddriver.azure.config
 
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomImageStorage
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.clouddriver.security.AccessControlledAccountDefinition
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinition
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.Canonical
 import groovy.transform.ToString
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 
 class AzureConfigurationProperties {
+  String defaultNamingStrategy = "default"
 
   @ToString(includeNames = true)
-  static class ManagedAccount {
+  @JsonTypeName("azure")
+  static class ManagedAccount implements AccessControlledAccountDefinition, CredentialsDefinition {
     String name
     String environment
     String accountType
@@ -34,6 +39,7 @@ class AzureConfigurationProperties {
     String appKey
     String tenantId
     String subscriptionId
+    String namingStrategy
     List<String> regions
     List<AzureVMImage> vmImages
     List<AzureCustomImageStorage> customImages

--- a/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/security/AzureAccountDefinitionSourceConfiguration.java
+++ b/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/security/AzureAccountDefinitionSourceConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.security;
+
+import com.netflix.spinnaker.clouddriver.azure.config.AzureConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty({"account.storage.enabled", "account.storage.azure.enabled"})
+public class AzureAccountDefinitionSourceConfiguration {
+
+  @Bean
+  public CredentialsDefinitionSource<AzureConfigurationProperties.ManagedAccount>
+      azureAccountSource(
+          AccountDefinitionRepository repository,
+          Optional<List<CredentialsDefinitionSource<AzureConfigurationProperties.ManagedAccount>>>
+              additionalSources,
+          AzureConfigurationProperties accountProperties) {
+    return new AccountDefinitionSource<>(
+        repository,
+        AzureConfigurationProperties.ManagedAccount.class,
+        additionalSources.orElseGet(() -> List.of(accountProperties::getAccounts)));
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/security/AzureAccountDefinitionSourceTest.java
+++ b/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/security/AzureAccountDefinitionSourceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.netflix.spinnaker.clouddriver.azure.config.AzureConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class AzureAccountDefinitionSourceTest {
+
+  @Test
+  public void testAzureAccountSourceReturnsAccountDefinitions() {
+    // Create test account
+    AzureConfigurationProperties.ManagedAccount mockAccount =
+        new AzureConfigurationProperties.ManagedAccount();
+    mockAccount.setName("test-azure-account");
+    mockAccount.setSubscriptionId("test-subscription-id");
+
+    // Mock repository
+    AccountDefinitionRepository repository = mock(AccountDefinitionRepository.class);
+    doReturn(Collections.singletonList(mockAccount)).when(repository).listByType(eq("azure"));
+
+    // Create configuration and additional sources
+    AzureConfigurationProperties configurationProperties = mock(AzureConfigurationProperties.class);
+    Optional<List<CredentialsDefinitionSource<AzureConfigurationProperties.ManagedAccount>>>
+        emptyAdditionalSources = Optional.empty();
+
+    // Create the source configuration
+    AzureAccountDefinitionSourceConfiguration sourceConfig =
+        new AzureAccountDefinitionSourceConfiguration();
+
+    // Get credentials definition source
+    CredentialsDefinitionSource<AzureConfigurationProperties.ManagedAccount> source =
+        sourceConfig.azureAccountSource(
+            repository, emptyAdditionalSources, configurationProperties);
+
+    // Verify source is created correctly
+    assertThat(source).isNotNull();
+    assertThat(source).isInstanceOf(AccountDefinitionSource.class);
+
+    // Get account definitions
+    List<AzureConfigurationProperties.ManagedAccount> accounts = source.getCredentialsDefinitions();
+
+    // Verify accounts are returned correctly
+    assertThat(accounts).isNotEmpty();
+    assertThat(accounts).hasSize(1);
+    assertThat(accounts.get(0).getName()).isEqualTo("test-azure-account");
+    assertThat(accounts.get(0).getSubscriptionId()).isEqualTo("test-subscription-id");
+  }
+}


### PR DESCRIPTION
This commit:
1. Updates AzureConfigurationProperties.ManagedAccount to implement AccessControlledAccountDefinition and CredentialsDefinition
2. Adds @JsonTypeName("azure") for proper type identification
3. Creates AzureAccountDefinitionSourceConfiguration for database integration

These changes enable the Account Management API for Azure provider.

