### PR TITLE
fix: resolve CVE findings 

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -29,6 +29,10 @@ ext {
     // https://github.com/springdoc/springdoc-openapi/blob/v2.8.17/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java#L85
     // referencing a field that didn't come in... until 2.2.30
     swagger          : "2.2.49",
+    httpcore5        : "5.4.3",
+    logback          : "1.5.37",
+    tomcat           : "10.1.56",
+    commonsCompress  : "1.27.1",
   ]
 }
 
@@ -48,6 +52,23 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform(libs.kotlin.bom))
+  // log4j-bom and netty-bom are declared here, before spring-boot-dependencies (and every
+  // other BOM below), so that our pinned versions win when this platform is published as a
+  // Maven POM and consumed by a downstream Maven-style build via an imported/enforced
+  // platform. Gradle's own conflict resolution picks the highest version regardless of
+  // declaration order, but Maven's <dependencyManagement> import resolution is strictly
+  // "first import wins" - so if these came after spring-boot-dependencies in the generated
+  // POM, Maven consumers would silently fall back to spring's older, nested netty-bom/log4j-bom
+  // versions even though Gradle-based, build-from-source consumers would never see the problem.
+  api(platform("org.apache.logging.log4j:log4j-bom:${versions.log4j}"))
+  api(platform("io.netty:netty-bom:4.1.136.Final"))// 3.5.16 of spring brings in 4.1.135 which has a new CVE.  https://nvd.nist.gov/vuln/detail/CVE-2026-55831.  Remove post upgrade to latest 4 with a fix
+  // httpcore5-parent is the officially published Maven coordinate management POM for the
+  // httpcore5/httpcore5-h2 artifact family (see the "Maven Coordinates" section of the
+  // Apache HttpComponents Core release docs). It has a real <dependencyManagement> pinning
+  // httpcore5/httpcore5-h2 to ${project.version}, so it's a safe drop-in for our former
+  // constraints{} pin. Declared here, before spring-boot-dependencies, for the same
+  // import-order-safety reason as log4j-bom/netty-bom above.
+  api(platform("org.apache.httpcomponents.core5:httpcore5-parent:${versions.httpcore5}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
@@ -58,8 +79,6 @@ dependencies {
   api(platform("org.spockframework:spock-bom:2.4-groovy-4.0"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:3.21.0"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
-  api(platform("org.apache.logging.log4j:log4j-bom:${versions.log4j}"))
-  api(platform("io.netty:netty-bom:4.1.136.Final"))// 3.5.16 of spring brings in 4.1.135 which has a new CVE.  https://nvd.nist.gov/vuln/detail/CVE-2026-55831.  Remove post upgrade to latest 4 with a fix
   constraints {
     api("cglib:cglib-nodep:3.3.0")
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
@@ -113,6 +132,7 @@ dependencies {
     api("commons-configuration:commons-configuration:1.8")
     api("commons-io:commons-io:2.22.0")
     api("commons-fileupload:commons-fileupload:1.6.0")// Multiple CVEs from 1.4
+    api("org.apache.commons:commons-compress:${versions.commonsCompress}")
     // CVE's in 3.2.1
     api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("org.apache.commons:commons-collections4:4.5.0")
@@ -124,6 +144,17 @@ dependencies {
     api("io.swagger.core.v3:swagger-core:${versions.swagger}")
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
+    // No official logback BOM exists (qos-ch/logback removed logback-bom in 2017; the
+    // internal logback-parent reactor POM is not documented/published for external
+    // consumers to import as a platform), so we keep pinning these two explicitly.
+    api("ch.qos.logback:logback-core:${versions.logback}")
+    api("ch.qos.logback:logback-classic:${versions.logback}")
+    // No official Tomcat BOM exists (no tomcat-embed-bom is published); Tomcat expects
+    // consumers to pin org.apache.tomcat.embed:* artifacts individually, or via Spring
+    // Boot's BOM, so we keep pinning these explicitly with a shared version variable.
+    api("org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcat}")
+    api("org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcat}")
+    api("org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcat}")
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.logging.log4j:log4j-api-kotlin:${versions.log4jKotlin}")
     api("org.bitbucket.b_c:jose4j:0.9.6")

--- a/rosco/rosco-manifests/rosco-manifests.gradle
+++ b/rosco/rosco-manifests/rosco-manifests.gradle
@@ -8,7 +8,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.spinnaker.kork:kork-core"
   implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.21"
+  implementation "org.apache.commons:commons-compress"
   implementation "org.yaml:snakeyaml"
 
   implementation "com.squareup.retrofit2:retrofit"

--- a/rosco/rosco-web/rosco-web.gradle
+++ b/rosco/rosco-web/rosco-web.gradle
@@ -28,7 +28,7 @@ dependencies {
   testImplementation "com.squareup.retrofit2:retrofit"
   testImplementation "com.squareup.retrofit2:converter-jackson"
   testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
-  testImplementation "org.apache.commons:commons-compress:1.21"
+  testImplementation "org.apache.commons:commons-compress"
   testImplementation "org.assertj:assertj-core"
 }
 


### PR DESCRIPTION
resolve CVE findings in commons-compress, logback, httpcore5, tomcat-embed, and Netty/Log4j BOM precedence

Pins a set of transitively-managed dependencies in spinnaker-dependencies.gradle to versions that resolve known vulnerability scan findings, and fixes a BOM-import-ordering bug that could silently undo one of those pins for certain downstream consumers.

- Adds explicit constraints { api(...) } overrides for commons-compress, logback-core/logback-classic, and tomcat-embed-core/-el/-websocket, so these resolve to patched versions instead of whatever Spring Boot's managed BOM happens to bring in.
- Imports the officially published org.apache.httpcomponents.core5:httpcore5-parent POM as a platform (instead of a manual constraints{} pin) to manage httpcore5/httpcore5-h2, since that artifact ships a real <dependencyManagement> section for those two modules. No equivalent official BOM exists for logback or tomcat-embed-*, so those remain as explicit constraints with a shared version variable; commons-compress is a single standalone artifact with no BOM of its own.
- Reorders the netty-bom, log4j-bom, and (new) httpcore5-parent platform imports to be declared before spring-boot-dependencies (and every other BOM) in spinnaker-dependencies.gradle.

Each of the pinned libraries had a CVE fixed by the newer version referenced here.

The Netty/Log4j fix is a bit different: netty-bom/log4j-bom were already being imported at their fixed versions, but they were declared after spring-boot-dependencies. Gradle's own conflict resolution picks the highest version regardless of declaration order when platforms are separate top-level dependencies, so build-from-source consumers never saw a problem. However, when spinnaker-dependencies is published as a Maven POM and consumed externally via an imported/enforced platform (e.g. enforcedPlatform(...)), both Maven's and Gradle's own dependencyManagement-import resolution treat the nested BOM imports inside that single published POM as strictly "first import wins" - so Spring Boot's own older, nested netty-bom/log4j-bom versions were silently winning over ours in that consumption path. This is why it wasn't caught by our own build/test process, which only ever builds from source.

clouddriver/gradle.properties no longer bumps commonsCompressVersion (kept at its original 1.21). That local property is redundant now that spinnaker-dependencies constrains org.apache.commons:commons-compress to 1.27.1: every clouddriver subproject applies enforcedPlatform("io.spinnaker.kork: kork-bom") (which in turn imports spinnaker-dependencies), so the constraint is forced and wins conflict resolution over the five modules that still reference $commonsCompressVersion directly, regardless of what that property is set to.

Verification performed:
- Reproduced the Netty/Log4j precedence bug with a real Maven-POM-consumption test: published spinnaker-dependencies to mavenLocal and resolved it from a throwaway Maven module that imports the published POM. Before the fix, io.netty:netty-codec and org.apache.logging.log4j:log4j-core resolved to Spring Boot's older versions instead of the pinned ones.
- Additionally reproduced the same bug (and confirmed the same fix) using a throwaway Gradle consumer applying enforcedPlatform("io.spinnaker.kork: spinnaker-dependencies:<version>") against the mavenLocal-published artifact, matching how downstream Gradle builds actually consume this platform as an external coordinate (not a source-level composite/project reference). Before the fix: netty-codec resolved to 4.1.135.Final and log4j-core to 2.24.3 (Spring Boot's nested versions). After the fix: netty-codec resolved to 4.1.136.Final and log4j-core to 2.26.1 (our pinned versions). This confirms the import-order sensitivity is not a Maven-only artifact of Maven's resolver - Gradle's own external-POM parsing exhibits the same first-import- wins behavior for nested BOM imports inside one published platform POM.
- Confirmed the same consumer resolves netty-codec/log4j-core, httpcore5/ httpcore5-h2, logback-classic, tomcat-embed-core, and commons-compress all to the correct pinned versions after the fix, through the same external- coordinate consumption path.
- Ran dependencyInsight on all five modules that reference commonsCompressVersion directly (clouddriver-appengine, clouddriver-artifacts-gitrepo, clouddriver-cloudrun, clouddriver-docker, clouddriver-lambda) with the local property reverted to 1.21: all five still resolve org.apache.commons: commons-compress to 1.27.1, with Gradle reporting "By constraint / Forced / By conflict resolution: between versions 1.27.1 and 1.21" - confirming the property bump was redundant and safe to drop.
- Ran kork-web/kork-aws dependency resolution, resolved and compiled clouddriver-aws (a consumer of httpcore5) from source, and ran the clouddriver-artifacts-gitrepo test suite (41 tests) - no regressions.

Note: an earlier version of this change also excluded software.amazon.ion:ion-java in favor of com.amazon.ion:ion-java for a separate CVE. Follow-up investigation found that finding was a false positive - the pinned aws-java-sdk-core version doesn't pull software.amazon.ion:ion-java into the dependency graph in a way that matters here - so that change is not included in this commit.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
